### PR TITLE
windows: call magick directly instead of via cmd.exe

### DIFF
--- a/lib/mogrify.ex
+++ b/lib/mogrify.ex
@@ -434,7 +434,7 @@ defmodule Mogrify do
 
   defp default_command(command) do
     case :os.type() do
-      {:win32, _} -> {"cmd.exe", ["/c", "magick", "#{command}"]}
+      {:win32, _} -> {"magick", ["#{command}"]}
       _ -> {"#{command}", []}
     end
   end


### PR DESCRIPTION
calling it directly is faster, and fixes
issues passing certain arguments such as resize_to_limit/2