### PR TITLE
Identify format option

### DIFF
--- a/lib/mogrify.ex
+++ b/lib/mogrify.ex
@@ -17,9 +17,7 @@ defmodule Mogrify do
 
   @doc """
   Saves modified image.
-
   ## Options
-
   * `:path` - The output path of the image. Defaults to a temporary file.
   * `:in_place` - Overwrite the original image, ignoring `:path` option. Default `false`.
   """
@@ -55,12 +53,9 @@ defmodule Mogrify do
 
   @doc """
   Creates or saves image.
-
   Uses the `convert` command, which accepts both existing images, or image
   operators. If you have an existing image, prefer save/2.
-
   ## Options
-
   * `:path` - The output path of the image. Defaults to a temporary file.
   * `:in_place` - Overwrite the original image, ignoring `:path` option. Default `false`.
   * `:buffer` - Pass `true` to write to Collectable in Image.buffer instead of file.
@@ -84,14 +79,10 @@ defmodule Mogrify do
 
   @doc """
   Returns the histogram of the image
-
   Runs ImageMagick's `histogram:info:-` command.
-
   Results are returned as a list of maps where each map includes keys red,
   blue, green, hex and count.
-
   ## Examples
-
       iex> open("test/fixtures/rbgw.png") |> histogram
       [
         %{"alpha" => 255, "blue" => 255, "count" => 400, "green" => 0, "hex" => "#0000ff", "red" => 0},
@@ -99,7 +90,6 @@ defmodule Mogrify do
         %{"alpha" => 255, "blue" => 0, "count" => 525, "green" => 0, "hex" => "#ff0000", "red" => 255},
         %{"alpha" => 255, "blue" => 255, "count" => 1350, "green" => 255, "hex" => "#ffffff", "red" => 255}
       ]
-
   """
   def histogram(image) do
     img = image |> custom("format", "%c")
@@ -142,7 +132,6 @@ defmodule Mogrify do
   defp clean_histogram_entry({"hex", v}), do: {"hex", v}
   defp clean_histogram_entry({"alpha", ""}), do: {"alpha", 255}
   defp clean_histogram_entry({k, ""}), do: {k, 0}
-
   defp clean_histogram_entry({k, v}), do: {k, v |> Float.parse() |> elem(0) |> Float.round(0) |> trunc}
 
   def extract_histogram_data(entry) do
@@ -162,8 +151,7 @@ defmodule Mogrify do
   defp output_path_for(image, save_opts) do
     cond do
       save_opts[:in_place] -> image.path
-      # temp file to ensure image format applied
-      image.dirty[:path] -> temporary_path_for(image)
+      image.dirty[:path] -> temporary_path_for(image)  # temp file to ensure image format applied
       save_opts[:path] -> save_opts[:path]
       true -> temporary_path_for(image)
     end
@@ -231,7 +219,6 @@ defmodule Mogrify do
 
   @doc """
   Provides detailed information about the image.
-
   This corresponds to the `mogrify -verbose` output which is similar to `identify`.
   It does NOT correspond to `identify -verbose` which prints out much more information.
   """
@@ -279,7 +266,6 @@ defmodule Mogrify do
 
   defp put_frame_count(%{animated: false} = map, _),
     do: Map.put(map, :frame_count, 1)
-
   defp put_frame_count(map, text) do
     # skip the [0] lines which may be duplicated
     matches = Regex.scan(~r/\b\[[1-9][0-9]*] \S+ \d+x\d+/, text)
@@ -299,9 +285,8 @@ defmodule Mogrify do
     %{
       image
       | operations: image.operations ++ [format: format],
-        dirty:
-          %{path: "#{rootname}#{ext}", format: downcase_format, ext: ext}
-          |> Enum.into(image.dirty)
+        dirty: %{path: "#{rootname}#{ext}", format: downcase_format, ext: ext}
+               |> Enum.into(image.dirty)
     }
   end
 
@@ -336,7 +321,6 @@ defmodule Mogrify do
   @doc """
   Resize the image to fit within the specified dimensions while retaining
   the original aspect ratio.
-
   Will only resize the image if it is larger than the specified dimensions. The
   resulting image may be shorter or narrower than specified in the smaller
   dimension but will not be larger than the specified values.
@@ -348,7 +332,6 @@ defmodule Mogrify do
   @doc """
   Resize the image to fit within the specified dimensions while retaining
   the aspect ratio of the original image.
-
   If necessary, crop the image in the larger dimension.
   """
   def resize_to_fill(image, params) do
@@ -412,7 +395,9 @@ defmodule Mogrify do
 
       raise ArgumentError,
         message:
-          "the option #{option_name} need arguments. Be sure to pass arguments to option_#{prefix}#{option_name}(arg)"
+          "the option #{option_name} need arguments. Be sure to pass arguments to option_#{prefix}#{
+            option_name
+          }(arg)"
     end
   end
 
@@ -451,7 +436,6 @@ defmodule Mogrify do
     config = Application.get_env(:mogrify, :"#{command}_command", [])
     path = Keyword.get(config, :path)
     args = Keyword.get(config, :args, [])
-
     if path do
       {path, args}
     else

--- a/lib/mogrify.ex
+++ b/lib/mogrify.ex
@@ -143,8 +143,7 @@ defmodule Mogrify do
   defp clean_histogram_entry({"alpha", ""}), do: {"alpha", 255}
   defp clean_histogram_entry({k, ""}), do: {k, 0}
 
-  defp clean_histogram_entry({k, v}),
-    do: {k, v |> Float.parse() |> elem(0) |> Float.round(0) |> trunc}
+  defp clean_histogram_entry({k, v}), do: {k, v |> Float.parse() |> elem(0) |> Float.round(0) |> trunc}
 
   def extract_histogram_data(entry) do
     ~r/^\s+(?<count>\d+):\s+\((?<red>[\d(?:\.\d+)?)\s]+),(?<green>[\d(?:\.\d+)?)\s]+),(?<blue>[\d(?:\.\d+)?)\s]+)(,(?<alpha>[\d(?:\.\d+)?)\s]+))?\)\s+(?<hex>\#[abcdef\d]{6,8})\s+/i
@@ -254,9 +253,9 @@ defmodule Mogrify do
 
   @doc """
   Provides "identify" information about an image with raw access attribute.
-  Example: identify(file_path, "'%[orientation]'")
+  Example: identify(file_path, format: "'%[orientation]'")
   """
-  def identify(file_path, option) do
+  def identify(file_path, format: option) do
     args = ["-format"] ++ [option] ++ [file_path]
     {output, 0} = cmd_identify(args, stderr_to_stdout: false)
     output |> String.replace("'", "")

--- a/test/mogrify_test.exs
+++ b/test/mogrify_test.exs
@@ -358,7 +358,7 @@ defmodule MogrifyTest do
   end
 
   test ".identify_option" do
-    assert "Undefined" = identify(@fixture, "'%[orientation]'")
+    assert "Undefined" = identify(@fixture, format: "'%[orientation]'")
   end
 
   test ".format" do

--- a/test/mogrify_test.exs
+++ b/test/mogrify_test.exs
@@ -357,6 +357,10 @@ defmodule MogrifyTest do
     assert %{format: "jpeg", height: 292, width: 300, animated: false} = identify(@fixture)
   end
 
+  test ".identify_option" do
+    assert "Undefined" = identify(@fixture, "'%[orientation]'")
+  end
+
   test ".format" do
     image = open(@fixture) |> format("png") |> save |> verbose
     assert %Image{ext: ".png", format: "png", height: 292, width: 300} = image
@@ -431,7 +435,8 @@ defmodule MogrifyTest do
     assert size_implicit == size_explicit
   end
 
-  @tag :skip  # broken on ImageMagick 6.8.9.9
+  # broken on ImageMagick 6.8.9.9
+  @tag :skip
   test ".custom annotate with multiple words" do
     path1 = Path.join(System.tmp_dir(), "1annotate.jpg")
     path2 = Path.join(System.tmp_dir(), "2annotate.jpg")
@@ -533,7 +538,7 @@ defmodule MogrifyTest do
       }
     ]
 
-    assert hist ==  expected
+    assert hist == expected
   end
 
   test ".histogram with fractional rgb values succeeds" do
@@ -542,26 +547,86 @@ defmodule MogrifyTest do
       |> custom("-alpha", "remove")
       |> custom("-colors", 8)
       |> histogram()
+
     assert is_list(hist) and length(hist) > 0
   end
 
-  @tag :skip  # RGB values and counts differ by system and ImageMagick version
+  # RGB values and counts differ by system and ImageMagick version
+  @tag :skip
   test ".histogram with fractional rgb values" do
     hist =
       open(@fixture)
       |> custom("-alpha", "remove")
       |> custom("-colors", 8)
       |> histogram()
-    expected =  [
-      %{"alpha" => 255, "blue" => 34, "count" => 1976, "green" => 33, "hex" => "#202122", "red" => 32},
-      %{"alpha" => 255, "blue" => 64, "count" => 2424, "green" => 63, "hex" => "#3E3F40", "red" => 62},
-      %{"alpha" => 255, "blue" => 103, "count" => 4669, "green" => 101, "hex" => "#656567", "red" => 101},
-      %{"alpha" => 255, "blue" => 127, "count" => 1319, "green" => 128, "hex" => "#7D807F", "red" => 125},
-      %{"alpha" => 255, "blue" => 129, "count" => 4915, "green" => 129, "hex" => "#7F8181", "red" => 127},
-      %{"alpha" => 255, "blue" => 150, "count" => 5913, "green" => 148, "hex" => "#939496", "red" => 147},
-      %{"alpha" => 255, "blue" => 191, "count" => 8142, "green" => 192, "hex" => "#BDC0BF", "red" => 189},
-      %{"alpha" => 255, "blue" => 244, "count" => 58242, "green" => 245, "hex" => "#F4F5F4", "red" => 244}
+
+    expected = [
+      %{
+        "alpha" => 255,
+        "blue" => 34,
+        "count" => 1976,
+        "green" => 33,
+        "hex" => "#202122",
+        "red" => 32
+      },
+      %{
+        "alpha" => 255,
+        "blue" => 64,
+        "count" => 2424,
+        "green" => 63,
+        "hex" => "#3E3F40",
+        "red" => 62
+      },
+      %{
+        "alpha" => 255,
+        "blue" => 103,
+        "count" => 4669,
+        "green" => 101,
+        "hex" => "#656567",
+        "red" => 101
+      },
+      %{
+        "alpha" => 255,
+        "blue" => 127,
+        "count" => 1319,
+        "green" => 128,
+        "hex" => "#7D807F",
+        "red" => 125
+      },
+      %{
+        "alpha" => 255,
+        "blue" => 129,
+        "count" => 4915,
+        "green" => 129,
+        "hex" => "#7F8181",
+        "red" => 127
+      },
+      %{
+        "alpha" => 255,
+        "blue" => 150,
+        "count" => 5913,
+        "green" => 148,
+        "hex" => "#939496",
+        "red" => 147
+      },
+      %{
+        "alpha" => 255,
+        "blue" => 191,
+        "count" => 8142,
+        "green" => 192,
+        "hex" => "#BDC0BF",
+        "red" => 189
+      },
+      %{
+        "alpha" => 255,
+        "blue" => 244,
+        "count" => 58242,
+        "green" => 245,
+        "hex" => "#F4F5F4",
+        "red" => 244
+      }
     ]
+
     assert hist == expected
   end
 

--- a/test/mogrify_test.exs
+++ b/test/mogrify_test.exs
@@ -357,7 +357,7 @@ defmodule MogrifyTest do
     assert %{format: "jpeg", height: 292, width: 300, animated: false} = identify(@fixture)
   end
 
-  test ".identify_option" do
+  test ".identify with format" do
     assert "Undefined" = identify(@fixture, format: "'%[orientation]'")
   end
 
@@ -435,8 +435,7 @@ defmodule MogrifyTest do
     assert size_implicit == size_explicit
   end
 
-  # broken on ImageMagick 6.8.9.9
-  @tag :skip
+  @tag :skip  # broken on ImageMagick 6.8.9.9
   test ".custom annotate with multiple words" do
     path1 = Path.join(System.tmp_dir(), "1annotate.jpg")
     path2 = Path.join(System.tmp_dir(), "2annotate.jpg")
@@ -538,7 +537,7 @@ defmodule MogrifyTest do
       }
     ]
 
-    assert hist == expected
+    assert hist ==  expected
   end
 
   test ".histogram with fractional rgb values succeeds" do
@@ -547,86 +546,26 @@ defmodule MogrifyTest do
       |> custom("-alpha", "remove")
       |> custom("-colors", 8)
       |> histogram()
-
     assert is_list(hist) and length(hist) > 0
   end
 
-  # RGB values and counts differ by system and ImageMagick version
-  @tag :skip
+  @tag :skip  # RGB values and counts differ by system and ImageMagick version
   test ".histogram with fractional rgb values" do
     hist =
       open(@fixture)
       |> custom("-alpha", "remove")
       |> custom("-colors", 8)
       |> histogram()
-
-    expected = [
-      %{
-        "alpha" => 255,
-        "blue" => 34,
-        "count" => 1976,
-        "green" => 33,
-        "hex" => "#202122",
-        "red" => 32
-      },
-      %{
-        "alpha" => 255,
-        "blue" => 64,
-        "count" => 2424,
-        "green" => 63,
-        "hex" => "#3E3F40",
-        "red" => 62
-      },
-      %{
-        "alpha" => 255,
-        "blue" => 103,
-        "count" => 4669,
-        "green" => 101,
-        "hex" => "#656567",
-        "red" => 101
-      },
-      %{
-        "alpha" => 255,
-        "blue" => 127,
-        "count" => 1319,
-        "green" => 128,
-        "hex" => "#7D807F",
-        "red" => 125
-      },
-      %{
-        "alpha" => 255,
-        "blue" => 129,
-        "count" => 4915,
-        "green" => 129,
-        "hex" => "#7F8181",
-        "red" => 127
-      },
-      %{
-        "alpha" => 255,
-        "blue" => 150,
-        "count" => 5913,
-        "green" => 148,
-        "hex" => "#939496",
-        "red" => 147
-      },
-      %{
-        "alpha" => 255,
-        "blue" => 191,
-        "count" => 8142,
-        "green" => 192,
-        "hex" => "#BDC0BF",
-        "red" => 189
-      },
-      %{
-        "alpha" => 255,
-        "blue" => 244,
-        "count" => 58242,
-        "green" => 245,
-        "hex" => "#F4F5F4",
-        "red" => 244
-      }
+    expected =  [
+      %{"alpha" => 255, "blue" => 34, "count" => 1976, "green" => 33, "hex" => "#202122", "red" => 32},
+      %{"alpha" => 255, "blue" => 64, "count" => 2424, "green" => 63, "hex" => "#3E3F40", "red" => 62},
+      %{"alpha" => 255, "blue" => 103, "count" => 4669, "green" => 101, "hex" => "#656567", "red" => 101},
+      %{"alpha" => 255, "blue" => 127, "count" => 1319, "green" => 128, "hex" => "#7D807F", "red" => 125},
+      %{"alpha" => 255, "blue" => 129, "count" => 4915, "green" => 129, "hex" => "#7F8181", "red" => 127},
+      %{"alpha" => 255, "blue" => 150, "count" => 5913, "green" => 148, "hex" => "#939496", "red" => 147},
+      %{"alpha" => 255, "blue" => 191, "count" => 8142, "green" => 192, "hex" => "#BDC0BF", "red" => 189},
+      %{"alpha" => 255, "blue" => 244, "count" => 58242, "green" => 245, "hex" => "#F4F5F4", "red" => 244}
     ]
-
     assert hist == expected
   end
 


### PR DESCRIPTION
This PR provides a raw option for `identify` function http://www.imagemagick.org/script/escape.php
Example: `identify(@fixture, "'%[orientation]'")` 

